### PR TITLE
Android support for News Feed Cards

### DIFF
--- a/android/src/main/java/com/appboy/reactbridge/AppboyReactUtils.java
+++ b/android/src/main/java/com/appboy/reactbridge/AppboyReactUtils.java
@@ -1,0 +1,67 @@
+package com.appboy.reactbridge;
+
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeArray;
+import com.facebook.react.bridge.WritableNativeMap;
+
+import org.json.JSONObject;
+import org.json.JSONException;
+import org.json.JSONArray;
+
+import java.util.Iterator;
+
+public class AppboyReactUtils {
+  public static WritableMap convertJsonToMap(JSONObject jsonObject) throws JSONException {
+    WritableMap map = new WritableNativeMap();
+    Iterator<String> iterator = jsonObject.keys();
+
+    while (iterator.hasNext()) {
+      String key = iterator.next();
+      Object value = jsonObject.get(key);
+
+      if (value instanceof JSONObject) {
+        map.putMap(key, convertJsonToMap((JSONObject) value));
+      } else if (value instanceof  JSONArray) {
+        map.putArray(key, convertJsonToArray((JSONArray) value));
+      } else if (value instanceof  Boolean) {
+        map.putBoolean(key, (Boolean) value);
+      } else if (value instanceof  Integer) {
+        map.putInt(key, (Integer) value);
+      } else if (value instanceof  Double) {
+        map.putDouble(key, (Double) value);
+      } else if (value instanceof String)  {
+        map.putString(key, (String) value);
+      } else {
+        map.putString(key, value.toString());
+      }
+    }
+
+    return map;
+  }
+
+  public static WritableArray convertJsonToArray(JSONArray jsonArray) throws JSONException {
+    WritableArray array = new WritableNativeArray();
+
+    for (int i = 0; i < jsonArray.length(); i++) {
+      Object value = jsonArray.get(i);
+      if (value instanceof JSONObject) {
+        array.pushMap(convertJsonToMap((JSONObject) value));
+      } else if (value instanceof  JSONArray) {
+        array.pushArray(convertJsonToArray((JSONArray) value));
+      } else if (value instanceof  Boolean) {
+        array.pushBoolean((Boolean) value);
+      } else if (value instanceof  Integer) {
+        array.pushInt((Integer) value);
+      } else if (value instanceof  Double) {
+        array.pushDouble((Double) value);
+      } else if (value instanceof String)  {
+        array.pushString((String) value);
+      } else {
+        array.pushString(value.toString());
+      }
+    }
+
+    return array;
+  }
+}

--- a/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
+++ b/iOS/AppboyReactBridge/AppboyReactBridge/AppboyReactBridge.m
@@ -264,6 +264,51 @@ RCT_EXPORT_METHOD(requestFeedRefresh) {
   [[Appboy sharedInstance] requestFeedRefresh];
 }
 
+RCT_EXPORT_METHOD(getFeedCards:(RCTResponseSenderBlock)callback) {
+  NSMutableArray *jsonCards = [NSMutableArray array];
+  NSArray *cards = [[Appboy sharedInstance].feedController getCardsInCategories:ABKCardCategoryAll];
+
+  for (ABKCard *card in cards) {
+    NSError *error = nil;
+    NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:[card serializeToData] options:0 error:&error];
+
+    if (dict != nil && error == nil) {
+      [jsonCards addObject:dict];
+    } else {
+      RCTLogInfo(@"Warning: Error serializing feed card to JSON.");
+      error = nil;
+    }
+  }
+
+  [self reportResultWithCallback:callback andError:nil andResult:jsonCards];
+}
+
+RCT_EXPORT_METHOD(logFeedCardClick: (NSString *)id) {
+  NSArray *cards = [[Appboy sharedInstance].feedController getCardsInCategories:ABKCardCategoryAll];
+
+  for (ABKCard *card in cards) {
+    if ([card.idString isEqualToString:id]) {
+      [card logCardClicked];
+      break;
+    }
+  }
+}
+
+RCT_EXPORT_METHOD(logFeedCardImpression: (NSString *)id) {
+  NSArray *cards = [[Appboy sharedInstance].feedController getCardsInCategories:ABKCardCategoryAll];
+
+  for (ABKCard *card in cards) {
+    if ([card.idString isEqualToString:id]) {
+      [card logCardImpression];
+      break;
+    }
+  }
+}
+
+RCT_EXPORT_METHOD(logFeedDisplayed) {
+  [[Appboy sharedInstance] logFeedDisplayed];
+}
+
 RCT_EXPORT_METHOD(wipeData) {
   [Appboy wipeDataAndDisableForAppRun];
 }

--- a/index.js
+++ b/index.js
@@ -389,6 +389,34 @@ var ReactAppboy = {
   },
 
   /**
+   * Fetches the list of cards from News Feed.
+   */
+  getFeedCards: function(callback) {
+    callFunctionWithCallback(AppboyReactBridge.getFeedCards, [], callback);
+  },
+
+  /**
+   * Reports a feed card was clicked.
+   */
+  logFeedCardClick: function(id) {
+    AppboyReactBridge.logFeedCardClick(id);
+  },
+
+  /**
+   * Reports a feed card was displayed to the user.
+   */
+  logFeedCardImpression: function(id) {
+    AppboyReactBridge.logFeedCardImpression(id);
+  },
+
+  /**
+   * Reports that the feed was displayed.
+   */
+  logFeedDisplayed: function() {
+    AppboyReactBridge.logFeedDisplayed();
+  },
+
+  /**
   * Returns the current number of News Feed cards for the given category.
   * @param {CardCategory} category - Card category. Use ReactAppboy.CardCategory.ALL to get the total card count.
   * @param {function(error, result)} callback - A callback that receives the function call result.


### PR DESCRIPTION
It's now possible to fetch the News Feed Cards as JS objects. All the
cards props are automatically mapped based on the their type.

The following logging methods are also exported now:
- logFeedCardClick
- logFeedCardImpression
- logFeedDisplayed