### PR TITLE
Map null objects properly on Android

### DIFF
--- a/android/src/main/java/com/appboy/reactbridge/AppboyReactUtils.java
+++ b/android/src/main/java/com/appboy/reactbridge/AppboyReactUtils.java
@@ -32,6 +32,8 @@ public class AppboyReactUtils {
         map.putDouble(key, (Double) value);
       } else if (value instanceof String)  {
         map.putString(key, (String) value);
+      } else if (value == JSONObject.NULL) {
+        map.putNull(key);
       } else {
         map.putString(key, value.toString());
       }


### PR DESCRIPTION
The Android bridge was not mapping properly object attributes that were
assigned to null. On those cases, it was sending "null" as a string to
the other side of the bridge.